### PR TITLE
Update docs to get imgprocessor to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ Replace config file located `~/config/imageprocessor/security.config`
   <services>
     <service prefix="media/" name="CloudImageService" type="ImageProcessor.Web.Services.CloudImageService, ImageProcessor.Web">
       <settings>
+        <setting key="Container" value="[MediaPrefix]"/>
         <setting key="MaxBytes" value="8194304"/>
         <setting key="Timeout" value="30000"/>
-        <setting key="Host" value="http://{Your Unique Bucket Name}.s3.amazonaws.com/{Your Key Prefix}/"/>
+        <setting key="Host" value="http://{Your Unique Bucket Name}.s3.amazonaws.com"/>
       </settings>
     </service>
   </services>


### PR DESCRIPTION
Hey @DannerrQ 

Been using this package on a recent project and found out that imageprocessor didn't see to work with it.

Using the following versions:

```xml
<package id="UmbracoCms" version="8.15.1" targetFramework="net472" />
<package id="Our.Umbraco.FileSystemProviders.S3.Core" version="8.1.0" targetFramework="net472" />
<package id="Our.Umbraco.FileSystemProviders.S3.Media" version="8.1.1" targetFramework="net472" />
```

When I changed from having `/media` in the url and adding the specific Container value it started working again, so figured I'd pass along a PR with the change 🙂