### PR TITLE
Bucket prefix issue fixed

### DIFF
--- a/Umbraco.Storage.S3/Umbraco.Storage.S3.Media/BucketMediaFileSystemComposer.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3.Media/BucketMediaFileSystemComposer.cs
@@ -44,6 +44,7 @@ namespace Umbraco.Storage.S3.Media
             var bucketName = ConfigurationManager.AppSettings[$"{AppSettingsKey}:BucketName"];
             var bucketHostName = ConfigurationManager.AppSettings[$"{AppSettingsKey}:BucketHostname"];
             var bucketPrefix = ConfigurationManager.AppSettings[$"{AppSettingsKey}:MediaPrefix"];
+            var mediaPrefix = ConfigurationManager.AppSettings[$"{AppSettingsKey}:MediaFolderName"];
             var region = ConfigurationManager.AppSettings[$"{AppSettingsKey}:Region"];
             bool.TryParse(ConfigurationManager.AppSettings[$"{AppSettingsKey}:DisableVirtualPathProvider"], out var disableVirtualPathProvider);
 
@@ -67,7 +68,8 @@ namespace Umbraco.Storage.S3.Media
                 Region = region,
                 CannedACL = new S3CannedACL("public-read"),
                 ServerSideEncryptionMethod = "",
-                DisableVirtualPathProvider = disableVirtualPathProvider
+                DisableVirtualPathProvider = disableVirtualPathProvider,
+                MediaPrefix = mediaPrefix
             };
         }
     }

--- a/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemConfig.cs
+++ b/Umbraco.Storage.S3/Umbraco.Storage.S3/BucketFileSystemConfig.cs
@@ -10,6 +10,8 @@ namespace Umbraco.Storage.S3
 
         public string BucketPrefix { get; set; }
 
+        public string MediaPrefix { get; set; }
+
         public string Region { get; set; }
 
         public S3CannedACL CannedACL { get; set; }


### PR DESCRIPTION
At the moment multiple prefix paths are not supported 
_Eg: /prefix1/prefix2/prefix3/media_
above prefix will be directly saved to the database and images are not loading because of this
therefore image path should be like _"/media/imageName.xx"_
this code changes done to fix above issue